### PR TITLE
fix(IE): getRandomBytes fails when size=0 on IE.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -20,8 +20,9 @@ function randomBytes (size, cb) {
 
   // This will not work in older browsers.
   // See https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues
-  crypto.getRandomValues(rawBytes)
-
+  if(size > 0) {  // getRandomValues fails on IE if size == 0
+    crypto.getRandomValues(rawBytes)
+  }
   // phantomjs doesn't like a buffer being passed here
   var bytes = new Buffer(rawBytes.buffer)
 

--- a/browser.js
+++ b/browser.js
@@ -20,7 +20,7 @@ function randomBytes (size, cb) {
 
   // This will not work in older browsers.
   // See https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues
-  if(size > 0) {  // getRandomValues fails on IE if size == 0
+  if (size > 0) {  // getRandomValues fails on IE if size == 0
     crypto.getRandomValues(rawBytes)
   }
   // phantomjs doesn't like a buffer being passed here


### PR DESCRIPTION
Fun IE stuff.

On IE11 if you run: msCrypto.getRandomValues(new Uint8Array(0)) , it launches an exception:
InvalidStateError

If you do the same on chrome it returns an empty list as it should be.

So, I think not calling getRandomValues when the size is zero solves the problem.