### PR TITLE
browser: force newer version of safe-buffer to fix bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "zuul": "^3.7.2"
   },
   "dependencies": {
-    "safe-buffer": "^5.0.1"
+    "safe-buffer": "^5.1.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/crypto-browserify/randombytes/issues/9

The issue is that if another dependency is requiring `safe-buffer@5.0.1` (e.g., with `~5.0.1` instead of `^5.0.1`) it may be deduped and use the older version. However, it's important to have the newer version for `randombytes`.