### PR TITLE
add `module` export

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "2.1.0",
   "description": "random bytes from browserify stand alone",
   "main": "index.js",
+  "module": "browser.js",
+  "browser": "browser.js",
   "scripts": {
     "test": "standard && node test.js | tspec",
     "phantom": "zuul --phantom -- test.js",
@@ -22,7 +24,6 @@
     "url": "https://github.com/crypto-browserify/randombytes/issues"
   },
   "homepage": "https://github.com/crypto-browserify/randombytes",
-  "browser": "browser.js",
   "devDependencies": {
     "phantomjs": "^1.9.9",
     "standard": "^10.0.2",


### PR DESCRIPTION
Adding a `module` export makes rollup and webpack automatically use that package over the NodeJS one when importing it into a project.