### PR TITLE
Export the actual function

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -48,3 +48,5 @@ function randomBytes (size, cb) {
 
   return bytes
 }
+
+export default randomBytes


### PR DESCRIPTION
There wasn't any export making it difficult for webpack to pick it up upon doing
```js
import randomBytes from 'randombytes'
```