### PR TITLE
Use globalThis in place of global

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -13,7 +13,7 @@ function oldBrowser () {
 }
 
 var Buffer = require('safe-buffer').Buffer
-var crypto = global.crypto || global.msCrypto
+var crypto = globalThis.crypto || globalThis.msCrypto
 
 if (crypto && crypto.getRandomValues) {
   module.exports = randomBytes


### PR DESCRIPTION
I ran into issues with a JavaScript bundler (vite) and the resulting package not working in the browser due to `global` being undefined. [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) is the now widely supported standard way to access the global object. This PR changes the browser impl to use `globalThis` instead of `global`.